### PR TITLE
Use render_body() API instead of .text to get JSON response.

### DIFF
--- a/falcon_api_browse/templates/base.html
+++ b/falcon_api_browse/templates/base.html
@@ -32,6 +32,6 @@ Doc: {{ resource.__doc__ }}</pre>
     <h2>Response</h2>
     <pre>Status: {{ response.status }}</pre>
     <pre>Body:</pre>
-    <pre>{{ response.text|ppjson }}</pre>
+    <pre>{{ response.render_body()|ppjson }}</pre>
   </body>
 </html>

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,7 +58,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "574ef3d5cda2257237516454e130489fa0bdddf7c45ea74fe5ec2d8d88c496f7"
+content-hash = "4359fda7155e293a217c733050dac21ddaa2eb6f87b162434cb56e56f042cc52"
 
 [metadata.files]
 falcon = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-falcon = ">=2.0.0"
+falcon = ">=3.0.0"
 Jinja2 = ">=2.0.0"
 importlib-resources = "^5.4.0"
 


### PR DESCRIPTION
Also, since it is a new API in 3.x, add minimum version support for Falcon to
be 3.x and drop 2.x.

Fixes #5
